### PR TITLE
Corrige ordenação de concursos

### DIFF
--- a/src/app/oportunidades/alunos/pages/detalhe-oportunidade/detalhe-oportunidade.html
+++ b/src/app/oportunidades/alunos/pages/detalhe-oportunidade/detalhe-oportunidade.html
@@ -47,5 +47,5 @@
       <p>{{ anexo.nome }}</p>
     </button>
   </ion-list>
-
+  <ion-spinner *ngIf="!concurso" page-loading></ion-spinner>
 </module-page>

--- a/src/app/oportunidades/alunos/pages/detalhe-oportunidade/detalhe-oportunidade.ts
+++ b/src/app/oportunidades/alunos/pages/detalhe-oportunidade/detalhe-oportunidade.ts
@@ -32,7 +32,6 @@ export class DetalheOportunidadePage implements OnDestroy {
   /**
    *
    */
-
   ionViewDidLoad() {
     let id = this.navParams.data.id;
     this.AlunoService.loadConcurso(id);
@@ -62,13 +61,12 @@ export class DetalheOportunidadePage implements OnDestroy {
 
   /**
    *
-   showClassificados(concurso: Concurso) {
-     this.navCtrl.push('ClassificacaoPage', { concurso });
-    }
-*/
+   * 
+   */
   showCursos(concurso: Concurso) {
     this.navCtrl.push('CursosPage', { id: concurso.id });
   }
+
   /**
    *
    *
@@ -80,8 +78,4 @@ export class DetalheOportunidadePage implements OnDestroy {
       this.AlunoService.toggleFavorite(concurso);
     }
   }
-  
-  /**
-   *
-   */
 }

--- a/src/app/oportunidades/concurso/pages/concurso/concurso.html
+++ b/src/app/oportunidades/concurso/pages/concurso/concurso.html
@@ -36,6 +36,4 @@
     *ngIf="concurso.liberarClassificacao"
   ></large-button>
   <button *ngIf="!concurso.liberarClassificacao" ion-item no-lines>
-    <ion-label id="not-found"></ion-label>
-  </button>
 </module-page>

--- a/src/app/oportunidades/concurso/pages/concurso/concurso.html
+++ b/src/app/oportunidades/concurso/pages/concurso/concurso.html
@@ -35,5 +35,5 @@
     (click)="showAreas(concurso)"
     *ngIf="concurso.liberarClassificacao"
   ></large-button>
-  <button *ngIf="!concurso.liberarClassificacao" ion-item no-lines>
+  <ion-spinner *ngIf="!concurso.nome" page-loading></ion-spinner>
 </module-page>

--- a/src/app/oportunidades/concurso/pages/concurso/concurso.ts
+++ b/src/app/oportunidades/concurso/pages/concurso/concurso.ts
@@ -59,14 +59,13 @@ export class ConcursoPage implements OnDestroy {
   }
 
   /**
+   * 
    *
-   showClassificados(concurso: Concurso) {
-     this.navCtrl.push('ClassificacaoPage', { concurso });
-    }
-*/
+   */
   showAreas(concurso: Concurso) {
     this.navCtrl.push('AreasPage', { idConcurso: concurso.id, nomeConcurso: concurso.nome, areas: concurso.areas });
   }
+
   /**
    *
    *
@@ -78,7 +77,4 @@ export class ConcursoPage implements OnDestroy {
       this.selecaoService.toggleFavorite(concurso);
     }
   }
-  /**
-   *
-   */
 }

--- a/src/app/oportunidades/concurso/pages/concursos/concursos.html
+++ b/src/app/oportunidades/concurso/pages/concursos/concursos.html
@@ -9,11 +9,11 @@
     (ionCancel)="clear($event)">
   </ion-searchbar>
   <ion-content>
-    <ion-list-header *ngIf="filteredConcursos && filteredConcursos.length">
+    <ion-list-header *ngIf="concursosLength">
       {{filteredConcursos.length}} concursos encontrados
     </ion-list-header>
     <ion-list
-        [virtualScroll]="filteredConcursos" 
+        [virtualScroll]="concursos$ | async"
         [virtualTrackBy]="trackById"
       >
       <button
@@ -35,11 +35,10 @@
         </div>
       </button>
     </ion-list>
-    <ion-item *ngIf="filteredConcursos && !filteredConcursos.length" text-center no-lines id="not-found">
+    <ion-item *ngIf="concursosLength" text-center no-lines id="not-found">
       <h2>Nenhum concurso encontrado</h2>
       <p>Tente mudar o filtro da consulta</p>
     </ion-item>
-    <ion-spinner *ngIf="!filteredConcursos" page-loading></ion-spinner>
   </ion-content>
 
 </module-page>


### PR DESCRIPTION
## Do que se trata essa mudança?

* [ ] - Nova(s) funcionalidade(s)
* [x] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

## Concursos (DT)

Nova lógica de exibição do conteúdo, trazendo os favoritos no topo da lista. Um Subject `concursos$` é usado pra armazenar os itens que devem ser exibidos e só é atualizado pelo método `updateConcursos(concurso: Concurso[])`, que sempre traz os favoritos para o início do array. Esse método é chamado no `ionViewWillLoad()` e  em `search()`.

Plus:
Também foi adicionado um spinner de loading nas telas que mostram os detalhes dos concursos e dos cursos, enquanto os dados são carregados.

## Áreas impactadas

A lista de concursos irá exibir os favoritos no início, conforme esperado pelo usuário.

O usuário verá um spinner enquanto os detalhes dos concursos e cursos não estiverem carregados.

## Passos para reproduzir

1. Fazer login no app
2. Navegar até Oportunidades > Designação Temporária
3. Marcar um ou mais concursos como favoritos