### PR TITLE
fix(document-summary-list): Fix error when open edocs authenticated area

### DIFF
--- a/src/app/edocs/components/document-summary-list/document-summary-list.component.ts
+++ b/src/app/edocs/components/document-summary-list/document-summary-list.component.ts
@@ -8,9 +8,10 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { trackById } from '@espm/core';
-import { InfiniteScroll, NavController, Refresher } from 'ionic-angular';
+import { trackById, AuthQuery } from '@espm/core';
+import { InfiniteScroll, NavController, Refresher, App } from 'ionic-angular';
 import { untilDestroyed } from 'ngx-take-until-destroy';
+import { of } from 'rxjs/observable/of';
 import { Observable } from 'rxjs/Observable';
 import { filter, tap } from 'rxjs/operators';
 
@@ -35,7 +36,11 @@ export class DocumentSummaryListComponent implements OnChanges, OnInit, OnDestro
   /**
    *
    */
-  constructor(private docsService: DocumentsService, private docsQuery: DocumentsQuery, private navCtrl: NavController) {}
+  constructor(private docsService: DocumentsService, 
+    private docsQuery: DocumentsQuery, 
+    private navCtrl: NavController, 
+    private authQuery: AuthQuery,
+    protected appCtrl: App) {}
 
   /**
    *
@@ -50,6 +55,15 @@ export class DocumentSummaryListComponent implements OnChanges, OnInit, OnDestro
    *
    */
   ngOnInit(): void {
+    // permite acesso à tela se autenticados
+    const isAllowed = this.authQuery.isLoggedIn;
+
+    if (!isAllowed) {
+      this.documents$ = of([]);
+      this.hasMore$ = of(false);
+      this.isLoading$ = of(false);
+      return;
+    }
     this.documents$ = this.docsQuery.selectDocuments();
     this.hasMore$ = this.docsQuery.selectHasMore();
     this.isLoading$ = this.docsQuery.selectLoading();


### PR DESCRIPTION
## Do que se trata essa mudança?

* [ ] - Nova(s) funcionalidade(s)
* [X] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Corrigido exibição de uma mensagem de erro ao tentar acessar uma função do edocs que requer autenticação.

## Correção EDOCS

O componente `documents-summary-list` estava sendo renderizado mesmo com o método `ionViewCanEnter` do seu pai sendo implementado para verificar a autenticação. Para contornar o problema foi implementado essa verificação no componente filho que adiciona um comportamento padrão afim de evitar erros e realizar requisições indesejadas.

## Áreas impactadas

* EDOCS: todas as funcionalidades autenticadas.

## Passos para reproduzir

1. Acessar o ESPM como visitante (não autenticado).
2. Entrar no serviço do EDOCS.
3. Tentar abrir todas as funcionalidades autenticadas, mesmo sem estar logado.

Não deverá ser exibida a mensagem "Erro inesperado" e nem chamadas na api do EDOCS.
