### PR TITLE
Fix/wrong titles texts

### DIFF
--- a/src/app/civil-servant/components/paystub-download/paystub-download.component.html
+++ b/src/app/civil-servant/components/paystub-download/paystub-download.component.html
@@ -2,7 +2,7 @@
   <ion-item class="sub-header">
     <ion-row>
       <ion-col>
-        <h2>PRODEST</h2>
+        <h2>{{ orgao }}</h2>
       </ion-col>
     </ion-row>
     <ion-row>

--- a/src/app/civil-servant/components/paystub-download/paystub-download.component.ts
+++ b/src/app/civil-servant/components/paystub-download/paystub-download.component.ts
@@ -16,6 +16,7 @@ export class PaystubDownloadComponent {
   @Output() onSelectPayroll: EventEmitter<IPaystubPayroll> = new EventEmitter();
   @Input() numVinc: number;
   @Input() numFunc: number;
+  @Input() orgao: string;
 
   constructor(public navCtrl: NavController, public navParams: NavParams) { }
 

--- a/src/app/civil-servant/components/report-yields-download/report-yields-download.component.html
+++ b/src/app/civil-servant/components/report-yields-download/report-yields-download.component.html
@@ -2,7 +2,7 @@
   <ion-item class="sub-header">
     <ion-row>
       <ion-col>
-        <h2>PRODEST</h2>
+        <h2>{{ orgao }}</h2>
       </ion-col>
     </ion-row>
     <ion-row>

--- a/src/app/civil-servant/components/report-yields-download/report-yields-download.component.ts
+++ b/src/app/civil-servant/components/report-yields-download/report-yields-download.component.ts
@@ -14,6 +14,7 @@ export class ReportYieldsDownloadComponent {
   @Output() onSelectCompany: EventEmitter<IReportYieldCompany> = new EventEmitter();
   @Input() numVinc: number;
   @Input() numFunc: number;
+  @Input() orgao: string;
 
   constructor(public navCtrl: NavController, public navParams: NavParams) { }
 

--- a/src/app/civil-servant/components/siarhes-profiles/siarhes-profiles.component.html
+++ b/src/app/civil-servant/components/siarhes-profiles/siarhes-profiles.component.html
@@ -1,4 +1,4 @@
-<p class="info">Selecione o perfil que deseja consultar o contracheque:</p>
+<p class="info">Selecione o perfil que deseja consultar:</p>
 <ion-list>
   <p class="text-danger" *ngIf="!profiles || profiles.length === 0">
     Não há perfis disponível no usuário atual.

--- a/src/app/civil-servant/pages/paystub/paystub.html
+++ b/src/app/civil-servant/pages/paystub/paystub.html
@@ -12,7 +12,7 @@
     <ion-item *ngSwitchCase="'download'">
       <paystub-download [years]="years$ | async" [months]="months$ | async" [numVinc]="currentLink?.numeroVinculo"
         [numFunc]="currentProfile?.numeroFuncionario" [payrolls]="payrolls$ | async" (onSelectYear)="getMonths($event)"
-        (onSelectMonth)="getPayrolls($event)" (onSelectPayroll)="download($event)"></paystub-download>
+        (onSelectMonth)="getPayrolls($event)" (onSelectPayroll)="download($event)" [orgao]="currentLink?.orgao"></paystub-download>
     </ion-item>
   </ion-list>
 </module-page>

--- a/src/app/civil-servant/pages/report-yields/report-yields.html
+++ b/src/app/civil-servant/pages/report-yields/report-yields.html
@@ -12,7 +12,7 @@
     <ion-item *ngSwitchCase="'download'">
       <report-yields-download [years]="years$ | async" [numVinc]="currentLink?.numeroVinculo"
         [numFunc]="currentProfile?.numeroFuncionario" [companies]="companies$ | async" (onSelectYear)="getCompanies($event)"
-        (onSelectCompany)="download($event)"></report-yields-download>
+        (onSelectCompany)="download($event)" [orgao]="currentLink?.orgao"></report-yields-download>
     </ion-item>
   </ion-list>
 </module-page>


### PR DESCRIPTION
## Do que se trata essa mudança?

* [ ] - Nova(s) funcionalidade(s)
* [X] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Acerto em alguns títulos

## Fix/wrong_titles_texts

* Retirada da palavra **contracheque** no subtítulo do componente *siarhes-profiles.component.html*
* Alteração do título dos componentes  *paystub-download.component.html* e *report-yields-download.component.html*. Antes estava fixo o nome **PRODEST** agora virá de acordo com o Órgão relacionado ao vinculo escolhido. 

## Áreas impactadas

* civil-servant/components/paystub-download
* civil-servant/components/report-yields-download
* civil-servant/components/siarhes-profiles/siarhes-profiles.component.html
* civil-servant/pages/paystub/paystub.html
* civil-servant/pages/report-yields/report-yields.html

## Passos para reproduzir

### Contracheque
1. Logar no *ESPM* com um usuário que receba o **Contracheque** pelo Governo do Estado;
2. Acessar o menu "Servidor";
3. Acessar a opção "Contracheque";
4. Selecionar o perfil;
5. Selecionar o vinculo;
6. Verificar se título acima de "Número do vínculo" é o nome do órgão associado ao vínculo.

### Informe Rendimento
1. Logar no *ESPM* com um usuário que receba o **Informe Rendimento** pelo Governo do Estado;
2. Acessar o menu "Servidor";
3. Acessar a opção "Informe Rendimento";
4. Selecionar o perfil;
5. Selecionar o vinculo;
6. Verificar se título acima de "Número do vínculo" é o nome do órgão associado ao vínculo.